### PR TITLE
Update VCC connection on underglow LED

### DIFF
--- a/pcb/Lily58.kicad_pcb
+++ b/pcb/Lily58.kicad_pcb
@@ -1,9 +1,9 @@
-(kicad_pcb (version 20171130) (host pcbnew "(6.0.0-rc1-dev-1672-g5c3f6f2ab)")
+(kicad_pcb (version 20171130) (host pcbnew "(5.1.4)-1")
 
   (general
     (thickness 1.6)
     (drawings 251)
-    (tracks 3126)
+    (tracks 3131)
     (zones 0)
     (modules 123)
     (nets 93)
@@ -3280,7 +3280,7 @@
     (pad "" np_thru_hole circle (at -5.22 4.2) (size 1 1) (drill 1) (layers *.Cu *.Mask F.SilkS))
   )
 
-  (module Lily58-footprint:MX_PG1350_FLIP_HOLES_18mm placed (layer F.Cu) (tedit 5AF69AB8) (tstamp 5D2E3A92)
+  (module Lily58-footprint:MX_PG1350_FLIP_HOLES_18mm placed (layer F.Cu) (tedit 5AF69AB8) (tstamp 5E294FF4)
     (at 196.7 90.5)
     (descr MXALPS)
     (tags MXALPS)
@@ -7884,6 +7884,11 @@
   (segment (start 189.6745 97.155) (end 188.722 98.1075) (width 0.5) (layer F.Cu) (net 34))
   (segment (start 193.987476 93.345) (end 190.9445 93.345) (width 0.5) (layer F.Cu) (net 34))
   (segment (start 188.722 98.1075) (end 185.8645 98.1075) (width 0.5) (layer F.Cu) (net 34))
+  (segment (start 192.538998 96.875) (end 190.855 96.875) (width 0.5) (layer B.Cu) (net 34))
+  (segment (start 190.855 96.875) (end 190.5 96.52) (width 0.5) (layer B.Cu) (net 34))
+  (segment (start 190.5 96.52) (end 190.5 93.98) (width 0.5) (layer B.Cu) (net 34))
+  (segment (start 190.5 93.98) (end 190.5 93.98) (width 0.5) (layer B.Cu) (net 34) (tstamp 5E29501F))
+  (via (at 190.5 93.98) (size 0.6) (drill 0.4) (layers F.Cu B.Cu) (net 34))
   (segment (start 84.15 45.6) (end 90.1 45.6) (width 0.5) (layer F.Cu) (net 35))
   (segment (start 93.25763 48.75) (end 93.389884 48.617746) (width 0.5) (layer F.Cu) (net 35) (tstamp 5BB1DE77))
   (segment (start 92.18 48.75) (end 93.25763 48.75) (width 0.5) (layer F.Cu) (net 35) (tstamp 5BB1DEE0))


### PR DESCRIPTION
During my build, I found that one of the under glow pads was not actually connected to VCC. Checking out the repo and opening it up in KiCAD quickly showed that there are two unrouted connections. One of these is that pad! Here is a quick fix, although I have not ordered a round of boards yet to confirm the fix it should be good to go. I have noticed the diff is rather large which is rather unsettling as far as merges go so but you can see what I was going for and conform the adjustments to your liking.   
 
### Dangling
![Annotation 2020-01-23 013451](https://user-images.githubusercontent.com/533852/72966096-a404a780-3d83-11ea-8c38-7cdfe653d1a8.png)

### No longer dangling
![Annotation 2020-01-23 013844](https://user-images.githubusercontent.com/533852/72966118-b1ba2d00-3d83-11ea-8f62-aa1c0f1ecd7e.png)


Thanks